### PR TITLE
fix: typo in Edrys module

### DIFF
--- a/command-runner.js
+++ b/command-runner.js
@@ -1,6 +1,6 @@
 async function run_command(command, timeout = 30000, host = "http://localhost", port = 8585, options = {}) {
-    host = Edyrs.module.config.command_runner_host || host
-    port = Edyrs.module.config.command_runner_port || port
+    host = Edrys.module.config.command_runner_host || host
+    port = Edrys.module.config.command_runner_port || port
 
     const abortController = new AbortController();
     const abortTimeout = setTimeout(() => abortController.abort(), timeout);

--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ class S(BaseHTTPRequestHandler):
         logging.info(f"GET request,\nPath: {self.path}\nHeaders:\n{self.headers}\n")
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
+        self.send_header('Access-Control-Allow-Origin', '*')
         self.end_headers()
 
         url = unquote(self.path[1:])


### PR DESCRIPTION
Just had to rename `Edyrs` to `Edrys`...